### PR TITLE
Make server's and proxy's onlinePlayers set synchronized in order to avoid errors due to multiple threads

### DIFF
--- a/TimoCloud-API/pom.xml
+++ b/TimoCloud-API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.TimoCloud</groupId>
-        <version>5.3.8</version>
+        <version>5.3.9</version>
     </parent>
 
     <artifactId>TimoCloud-API</artifactId>

--- a/TimoCloud-Universal/pom.xml
+++ b/TimoCloud-Universal/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.TimoCloud</groupId>
-        <version>5.3.8</version>
+        <version>5.3.9</version>
     </parent>
 
     <repositories>

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/objects/Proxy.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/objects/Proxy.java
@@ -26,7 +26,7 @@ public class Proxy implements Instance, Communicatable {
     private InetSocketAddress address;
     private Base base;
     private int onlinePlayerCount;
-    private Set<PlayerObject> onlinePlayers;
+    private final Set<PlayerObject> onlinePlayers;
     private Channel channel;
     private boolean starting;
     private boolean registered;
@@ -41,7 +41,7 @@ public class Proxy implements Instance, Communicatable {
         this.group = group;
         this.base = base;
         this.address = new InetSocketAddress(base.getAddress(), 0);
-        this.onlinePlayers = new HashSet<>();
+        this.onlinePlayers = Collections.synchronizedSet(new HashSet<>());
         this.registeredServers = new HashSet<>();
     }
 

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/objects/Server.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/objects/Server.java
@@ -29,7 +29,7 @@ public class Server implements Instance, Communicatable {
     private String state = "STARTING";
     private String extra = "";
     private String motd = "";
-    private Set<PlayerObject> onlinePlayers;
+    private final Set<PlayerObject> onlinePlayers;
     private int onlinePlayerCount = 0;
     private int maxPlayers = 0;
     private String map;
@@ -44,7 +44,7 @@ public class Server implements Instance, Communicatable {
         this.group = group;
         this.base = base;
         this.address = new InetSocketAddress(base.getAddress(), 0);
-        this.onlinePlayers = new HashSet<>();
+        this.onlinePlayers = Collections.synchronizedSet(new HashSet<>());
         this.map = map;
         if (this.map == null) this.map = "";
     }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>TimoCloud</artifactId>
     <packaging>pom</packaging>
 
-    <version>5.3.8</version>
+    <version>5.3.9</version>
 
     <modules>
         <module>TimoCloud-Universal</module>


### PR DESCRIPTION
Make server's and proxy's onlinePlayers set synchronized in order to avoid errors due to multiple threads

Fixes #51