### PR TITLE
5.4.2 - Universal-API method "getPlayer(String name" is no longer case sensitive; bugfixes

### DIFF
--- a/TimoCloud-API/pom.xml
+++ b/TimoCloud-API/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.TimoCloud</groupId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <artifactId>TimoCloud-API</artifactId>

--- a/TimoCloud-Universal/pom.xml
+++ b/TimoCloud-Universal/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>TimoCloud</artifactId>
         <groupId>cloud.timo.TimoCloud</groupId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <repositories>

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/api/implementations/TimoCloudUniversalAPIBasicImplementation.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/api/implementations/TimoCloudUniversalAPIBasicImplementation.java
@@ -146,9 +146,10 @@ public class TimoCloudUniversalAPIBasicImplementation implements TimoCloudUniver
 
     @Override
     public PlayerObject getPlayer(String name) {
+        name = name.toUpperCase();
         for (ProxyObject proxyObject : getProxyGroups().stream().map(ProxyGroupObject::getProxies).flatMap(List::stream).collect(Collectors.toList()))
             for (PlayerObject playerObject : proxyObject.getOnlinePlayers())
-                if (playerObject.getName().equals(name)) return playerObject;
+                if (playerObject.getName().toUpperCase().equals(name)) return playerObject;
         return null;
     }
 

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/bukkit/sockets/BukkitStringHandler.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/bukkit/sockets/BukkitStringHandler.java
@@ -14,6 +14,7 @@ import cloud.timo.TimoCloud.lib.sockets.BasicStringHandler;
 import cloud.timo.TimoCloud.lib.utils.EnumUtil;
 import cloud.timo.TimoCloud.lib.utils.PluginMessageSerializer;
 import io.netty.channel.Channel;
+import org.bukkit.Bukkit;
 
 import java.util.Map;
 
@@ -45,7 +46,7 @@ public class BukkitStringHandler extends BasicStringHandler {
                 }
                 break;
             case "EXECUTE_COMMAND":
-                TimoCloudBukkit.getInstance().getServer().dispatchCommand(TimoCloudBukkit.getInstance().getServer().getConsoleSender(), (String) data);
+                Bukkit.getScheduler().scheduleSyncDelayedTask(TimoCloudBukkit.getInstance(), () -> TimoCloudBukkit.getInstance().getServer().dispatchCommand(TimoCloudBukkit.getInstance().getServer().getConsoleSender(), (String)data));
                 break;
             case "PLUGIN_MESSAGE": {
                 AddressedPluginMessage addressedPluginMessage = PluginMessageSerializer.deserialize((Map) data);

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/api/TimoCloudUniversalAPICoreImplementation.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/api/TimoCloudUniversalAPICoreImplementation.java
@@ -64,9 +64,10 @@ public class TimoCloudUniversalAPICoreImplementation extends TimoCloudUniversalA
 
     @Override
     public PlayerObject getPlayer(String name) {
+        name = name.toUpperCase();
         for (Proxy proxy : TimoCloudCore.getInstance().getInstanceManager().getProxyGroups().stream().map(ProxyGroup::getProxies).flatMap(Collection::stream).collect(Collectors.toList()))
             for (PlayerObject playerObject : proxy.getOnlinePlayers())
-                if (playerObject.getName().equals(name)) return playerObject;
+                if (playerObject.getName().toUpperCase().equals(name)) return playerObject;
         return null;
     }
 }

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/RestartCommandHandler.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/RestartCommandHandler.java
@@ -4,11 +4,7 @@ import cloud.timo.TimoCloud.api.core.commands.CommandHandler;
 import cloud.timo.TimoCloud.api.core.commands.CommandSender;
 import cloud.timo.TimoCloud.core.TimoCloudCore;
 import cloud.timo.TimoCloud.core.commands.utils.CommandFormatUtil;
-import cloud.timo.TimoCloud.core.objects.Base;
-import cloud.timo.TimoCloud.core.objects.Proxy;
-import cloud.timo.TimoCloud.core.objects.ProxyGroup;
-import cloud.timo.TimoCloud.core.objects.Server;
-import cloud.timo.TimoCloud.core.objects.ServerGroup;
+import cloud.timo.TimoCloud.core.objects.*;
 
 import java.util.ArrayList;
 

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/SendCommandCommandHandler.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/commands/SendCommandCommandHandler.java
@@ -21,8 +21,8 @@ public class SendCommandCommandHandler  extends CommandFormatUtil implements Com
         ServerGroup serverGroup = TimoCloudCore.getInstance().getInstanceManager().getServerGroupByName(target);
         ProxyGroup proxyGroup = TimoCloudCore.getInstance().getInstanceManager().getProxyGroupByName(target);
 
-        Server server = TimoCloudCore.getInstance().getInstanceManager().getServerById(target);
-        Proxy proxy = TimoCloudCore.getInstance().getInstanceManager().getProxyById(target);
+        Server server = TimoCloudCore.getInstance().getInstanceManager().getServerByName(target);
+        Proxy proxy = TimoCloudCore.getInstance().getInstanceManager().getProxyByName(target);
 
         if (serverGroup == null && proxyGroup == null && server == null && proxy == null) {
             sender.sendError("Could not find any group, server or proxy with the name '" + target + "'");

--- a/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CoreInstanceManager.java
+++ b/TimoCloud-Universal/src/main/java/cloud/timo/TimoCloud/core/managers/CoreInstanceManager.java
@@ -380,7 +380,6 @@ public class CoreInstanceManager {
     /**
      * Searches for a server by name (case-insensitive)
      *
-     * @deprecated Use {@link CoreInstanceManager#getServerById(String)} instead
      * @param name The server's name (case-insensitive)
      * @return A server object
      */
@@ -410,7 +409,6 @@ public class CoreInstanceManager {
     /**
      * Searches for a proxy by name (case-insensitive)
      *
-     * @deprecated Use {@link CoreInstanceManager#getProxyById(String)} instead
      * @param name The proxy's name (case-insensitive)
      * @return A proxy object
      */

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>TimoCloud</artifactId>
     <packaging>pom</packaging>
 
-    <version>5.4.1</version>
+    <version>5.4.2</version>
 
     <modules>
         <module>TimoCloud-Universal</module>


### PR DESCRIPTION
This pull Request implements that the "getPlayer(String name)"-method of the Universal-API is no longer case sensitive.
It also contains several bugfixes:
  - commands that a bukkit-server receives will be executed sync now to avoid erros
  - the "sendcommand"-command works now again with a specified server or proxy; cause of that, the "getServerByName"- and the "getProxyByName"-method are no longer deprecated

Also, the imports were optimized and the version was updated.